### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     }
   ],
   "require": {
-    "illuminate/support": "^6.0",
+    "illuminate/support": "^6.0|^7.0|^8.0",
     "php": "^7.2",
-    "guzzlehttp/guzzle": "^6.0",
+    "guzzlehttp/guzzle": "^6.0|^7.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
This library works just fine with Guzzle 7 and Illuminate/Support 8 - this is simply and update to composer.json to allow theose  later versions of illuminate/support and guzzle.   I have it working with Laravel 8 and those packages.